### PR TITLE
[Doc] Add exists to support query types of QueryApiKey API (#87275)

### DIFF
--- a/x-pack/docs/en/rest-api/security/query-api-key.asciidoc
+++ b/x-pack/docs/en/rest-api/security/query-api-key.asciidoc
@@ -43,7 +43,8 @@ You can specify the following parameters in the request body:
 The query supports a subset of query types, including
 <<query-dsl-match-all-query,`match_all`>>, <<query-dsl-bool-query,`bool`>>,
 <<query-dsl-term-query,`term`>>, <<query-dsl-terms-query,`terms`>>, <<query-dsl-ids-query,`ids`>>,
-<<query-dsl-prefix-query,`prefix`>>, <<query-dsl-wildcard-query,`wildcard`>>, and <<query-dsl-range-query,`range`>>.
+<<query-dsl-prefix-query,`prefix`>>, <<query-dsl-wildcard-query,`wildcard`>>, <<query-dsl-exists-query,`exists`>>,
+and <<query-dsl-range-query,`range`>>.
 +
 You can query all public information associated with an API key, including the
 following values.
@@ -233,6 +234,7 @@ Use a `bool` query to issue complex logical conditions and use
 
 [source,js]
 ----
+GET /_security/_query/api_key
 {
   "query": {
     "bool": {
@@ -334,3 +336,43 @@ The response contains a list of matched API keys along with their sort values:
 
 <1> The first sort value is creation time, which is displayed in `date_time` <<mapping-date-format,format>> as defined in the request
 <2> The second sort value is the API key name
+
+You can use the following request to retrieve all valid API keys, i.e. not invalidated and not expired:
+[source,js]
+----
+GET /_security/_query/api_key
+{
+  "query": {
+    "bool": {
+      "must": {
+        "term": {
+          "invalidated": false  <1>
+        }
+      },
+      "should": [  <2>
+        {
+          "range": {
+            "expiration": {
+              "gte": "now"
+            }
+          }
+        },
+        {
+          "bool": {
+            "must_not": {
+              "exists": {
+                "field": "expiration"
+              }
+            }
+          }
+        }
+      ],
+      "minimum_should_match": 1
+    }
+  }
+}
+----
+// NOTCONSOLE
+
+<1> Matching API keys must not be invalidated
+<2> Matching API keys must be either not expired or does not have an expiration date


### PR DESCRIPTION
The exists query type is supported for QueryApiKey API since #87229.
This PR adds it to relevant doc page.

Relates: #87229

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
